### PR TITLE
ルーティングをパス指定から名前付きルートに変更

### DIFF
--- a/frontend/src/components/BookCreate.vue
+++ b/frontend/src/components/BookCreate.vue
@@ -9,7 +9,7 @@ const router = useRouter();
 
 const handleSubmit = async () => {
   await createBook({ title: title.value, author: author.value });
-  router.push("/");
+  router.push({ name: "BookList" });
 };
 </script>
 
@@ -21,6 +21,6 @@ const handleSubmit = async () => {
       <input v-model="author" placeholder="著者" required />
       <button type="submit">追加</button>
     </form>
-    <router-link to="/">戻る</router-link>
+    <router-link :to="{ name: 'BookList' }">戻る</router-link>
   </div>
 </template>

--- a/frontend/src/components/BookList.vue
+++ b/frontend/src/components/BookList.vue
@@ -18,5 +18,5 @@ onMounted(async () => {
       </li>
     </ul>
   </div>
-  <router-link to="/create">書籍追加</router-link>
+  <router-link :to="{ name: 'BookCreate' }">書籍追加</router-link>
 </template>


### PR DESCRIPTION
## 概要
Vue Router におけるルーティングの記述を、直接パス指定（"/" や "/create"）から名前付きルート（name: 'BookList' や 'BookCreate'）に変更しました。

## 変更内容
- `router.push("/")` → `router.push({ name: "BookList" })`
- `<router-link to="/">` → `<router-link :to="{ name: 'BookList' }">`
- `<router-link to="/create">` → `<router-link :to="{ name: 'BookCreate' }">`

## 目的
名前付きルートを使うことで、URL構造が将来変更されてもルーティングの記述を柔軟に保てるようにするため。

## 動作確認
- 書籍一覧画面から「書籍追加」リンクが機能すること
- 書籍追加後に一覧画面へ遷移できること
- 戻るリンクが正しく動作すること

## 補足
今後、ルートパスを変更した場合でも、`name` によるルーティングであれば対応が容易になります。
