### PR TITLE
書籍にステータス管理機能を追加

### DIFF
--- a/backend/books/urls.py
+++ b/backend/books/urls.py
@@ -1,9 +1,10 @@
 from rest_framework.routers import DefaultRouter
-from .views import BookViewSet
+from .views import BookViewSet, StatusVieSet
 from django.urls import path, include
 
 router = DefaultRouter()
 router.register(r'books', BookViewSet)
+router.register(r'statuses', StatusViewSet)
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/backend/books/urls.py
+++ b/backend/books/urls.py
@@ -1,5 +1,5 @@
 from rest_framework.routers import DefaultRouter
-from .views import BookViewSet, StatusVieSet
+from .views import BookViewSet, StatusViewSet
 from django.urls import path, include
 
 router = DefaultRouter()

--- a/backend/books/views.py
+++ b/backend/books/views.py
@@ -1,7 +1,12 @@
 from rest_framework import  viewsets
-from .models import Book
-from .serializers import BookSerializer
+from .models import Book, Status
+from .serializers import BookSerializer, StatusSerializer
 
 class BookViewSet(viewsets.ModelViewSet):
     queryset = Book.objects.all()
     serializer_class = BookSerializer
+
+
+class StatusViewSet(viewsets.ModelViewSet):
+    queryset = Status.objects.all()
+    serializer_class = StatusSerializer

--- a/frontend/src/api/books.js
+++ b/frontend/src/api/books.js
@@ -25,3 +25,16 @@ export const getBook = async (id) => {
   const response = await axios.get(`${API_BASE}${id}/`);
   return response.data;
 };
+
+// 書籍情報を部分的に更新(PATH)する処理
+export const updateBook = async (id, data) => {
+  const response = await fetch(`${API_BASE}${id}/`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!response.ok) {
+    throw new Error("書籍の更新に失敗しました。");
+  }
+  return await response.json();
+};

--- a/frontend/src/api/books.js
+++ b/frontend/src/api/books.js
@@ -35,3 +35,9 @@ export const updateBook = async (id, data) => {
     throw new Error("書籍の更新に失敗しました。");
   }
 };
+
+// Status情報の取得
+export const getStatuses = async () => {
+  const response = await axios.get(`${API_BASE}/statuses/`);
+  return response.data;
+};

--- a/frontend/src/api/books.js
+++ b/frontend/src/api/books.js
@@ -28,13 +28,10 @@ export const getBook = async (id) => {
 
 // 書籍情報を部分的に更新(PATH)する処理
 export const updateBook = async (id, data) => {
-  const response = await fetch(`${API_BASE}/books/${id}/`, {
-    method: "PATCH",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(data),
-  });
-  if (!response.ok) {
+  try {
+    const response = await axios.patch(`${API_BASE}/books/${id}/`, data);
+    return response.data;
+  } catch (error) {
     throw new Error("書籍の更新に失敗しました。");
   }
-  return await response.json();
 };

--- a/frontend/src/api/books.js
+++ b/frontend/src/api/books.js
@@ -1,34 +1,34 @@
 import axios from "axios";
 
-const API_BASE = "http://localhost:8001/api/books/";
+const API_BASE = "http://localhost:8001/api";
 
 // 書籍一覧を取得
 export const getBooks = async () => {
-  const response = await axios.get(API_BASE);
+  const response = await axios.get(`${API_BASE}/books/`);
   return response.data;
 };
 
 // 書籍を追加
 export const createBook = async (book) => {
-  const response = await axios.post(API_BASE, book);
+  const response = await axios.post(`${API_BASE}/books/`, book);
   return response.data;
 };
 
 // 書籍を削除
 export const deleteBook = async (id) => {
-  const response = await axios.delete(`${API_BASE}${id}/`);
+  const response = await axios.delete(`${API_BASE}/books/${id}/`);
   return response.data;
 };
 
 // 単一の書籍取得
 export const getBook = async (id) => {
-  const response = await axios.get(`${API_BASE}${id}/`);
+  const response = await axios.get(`${API_BASE}/books/${id}/`);
   return response.data;
 };
 
 // 書籍情報を部分的に更新(PATH)する処理
 export const updateBook = async (id, data) => {
-  const response = await fetch(`${API_BASE}${id}/`, {
+  const response = await fetch(`${API_BASE}/books/${id}/`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),


### PR DESCRIPTION
## 概要

書籍（Book）にステータス（Status）を紐づけて管理できる機能を追加しました。

## 主な変更点

### Backend（Django）

- `Status` モデル用の `StatusViewSet` を追加
- `urls.py` に `/api/statuses/` エンドポイントを追加し、ルーティングを設定
- Book に対して部分的更新（PATCH）可能なようにAPIを想定

### Frontend（Vue.js）

- 書籍詳細ページでステータスをプルダウンで変更できるUIを追加
- ステータス一覧を取得するAPI `getStatuses()` を追加
- 書籍の部分更新API `updateBook()` を追加
- ステータス変更後に `Book` 情報を再取得して反映
- APIエンドポイントのベースURLを統一（`api/books/` → `/api/`）


---
