### PR TITLE
書籍ステータスの更新機能を実装（status_id による更新・セレクト連携）

### DIFF
--- a/backend/books/serializers.py
+++ b/backend/books/serializers.py
@@ -7,7 +7,12 @@ class StatusSerializer(serializers.ModelSerializer):
                 fields = ['id', 'name']
 
 class BookSerializer(serializers.ModelSerializer):
+        # 読み込み時はネストしたstatus情報を表示
         status = StatusSerializer(read_only=True)
+        # 書き込み時はstatus_idでID指定可能にする
+        status_id = serializers.PrimaryKeyRelatedField(
+                queryset=Status.objects.all(), source='status', write_only=True
+        )
         class Meta:
                 model = Book
-                fields = ['id', 'title', 'author', 'status']
+                fields = ['id', 'title', 'author', 'status', 'status_id']


### PR DESCRIPTION
## 概要
書籍の詳細画面でステータスを更新できるようにしました。
API 側とフロントエンド側の両方を修正し、セレクトボックスによるステータス更新機能を追加しました。

---

## 変更内容

### Backend（Django REST Framework）
- `BookSerializer` に `status_id` を追加し、書き込み時に `status_id` による更新を可能に
- `status` は読み取り専用のネストされたデータとして保持

### Frontend（Vue 3）
- 書籍詳細画面で、現在のステータスを `<select>` にバインド（`localStatusId`）
- ステータス変更時に `updateBook` API を呼び出し、変更を反映
- 状態更新中はセレクトを一時的に無効化し、更新中表示を追加
- `nextTick()` を使って `book` データ取得後に正しい初期ステータスをバインド

---

## 補足
- API 側と通信しつつ、ローカル状態でステータス管理を行うことで UI の即時反映を実現
- 旧コードでは `book.status.id` を直接バインドしていたが、Vue のリアクティブ性と更新の流れを考慮して分離

---
## 関連Issue
Fixes #34
